### PR TITLE
Update inject macro to support containers

### DIFF
--- a/Sources/WhoopDIKit/Container/Container.swift
+++ b/Sources/WhoopDIKit/Container/Container.swift
@@ -87,7 +87,7 @@ public final class Container {
         if let value = try definition?.get(params: params) as? T {
             return value
         } else if let injectable = T.self as? any Injectable.Type {
-            return try injectable.inject() as! T
+            return try injectable.inject(container: self) as! T
         } else  {
             throw DependencyError.missingDependecy(ServiceKey(T.self, name: name))
         }

--- a/Sources/WhoopDIKit/Injectable/Injectable.swift
+++ b/Sources/WhoopDIKit/Injectable/Injectable.swift
@@ -3,5 +3,5 @@ import Foundation
 /// This protocol is used to create a detached injectable component without needing a dependency module.
 /// This is most likely used with the `@Injectable` macro, which will create the inject function and define it for you
 public protocol Injectable {
-    static func inject() throws -> Self
+    static func inject(container: Container) throws -> Self
 }

--- a/Sources/WhoopDIKit/WhoopDI.swift
+++ b/Sources/WhoopDIKit/WhoopDI.swift
@@ -1,6 +1,6 @@
 import Foundation
 public final class WhoopDI: DependencyRegister {
-    nonisolated(unsafe) private static let appContainer = Container()
+    nonisolated(unsafe) static let appContainer = Container()
     
     /// Registers a list of modules with the DI system.
     /// Typically you will create a `DependencyModule` for your feature, then add it to the module list provided to this method.

--- a/Sources/WhoopDIKit/WhoopDI.swift
+++ b/Sources/WhoopDIKit/WhoopDI.swift
@@ -1,6 +1,6 @@
 import Foundation
 public final class WhoopDI: DependencyRegister {
-    nonisolated(unsafe) static let appContainer = Container()
+    nonisolated(unsafe) private static let appContainer = Container()
     
     /// Registers a list of modules with the DI system.
     /// Typically you will create a `DependencyModule` for your feature, then add it to the module list provided to this method.

--- a/Sources/WhoopDIKitMacros/InjectableMacro.swift
+++ b/Sources/WhoopDIKitMacros/InjectableMacro.swift
@@ -25,7 +25,7 @@ struct InjectableMacro: ExtensionMacro, MemberMacro {
 
         // Creates the whoopdi calls in the `inject` func
         let injectingVariables: String = allVariables.map { variable in
-            "\(variable.name): WhoopDI.inject(\(variable.injectedName.map { "\"\($0)\"" } ?? "nil"))"
+            "\(variable.name): container.inject(\(variable.injectedName.map { "\"\($0)\"" } ?? "nil"))"
         }.joined(separator: ", ")
 
         let accessLevel = self.accessLevel(declaration: declaration) ?? "internal"
@@ -37,7 +37,7 @@ struct InjectableMacro: ExtensionMacro, MemberMacro {
             /// }
             """
             
-            \(raw: accessLevel) static func inject() -> Self {
+            \(raw: accessLevel) static func inject(container: Container) -> Self {
                 Self.init(\(raw: injectingVariables))
             }
             """,

--- a/Tests/WhoopDIKitTests/Container/ContainerTests.swift
+++ b/Tests/WhoopDIKitTests/Container/ContainerTests.swift
@@ -45,11 +45,16 @@ class ContainerTests: XCTestCase {
         }
         XCTAssertTrue(dependency is DependencyB)
     }
-
-    func test_injecting() throws {
-        throw XCTSkip("TODO: implement once WhoopDI uses a DI container")
+    
+    func test_injectableWithDependency() throws {
         container.registerModules(modules: [FakeTestModuleForInjecting()])
-        let testInjecting: TestInjectingThing = container.inject()
-        XCTAssertEqual(testInjecting, TestInjectingThing(name: 1))
+        let testInjecting: InjectableWithDependency = container.inject()
+        XCTAssertEqual(testInjecting, InjectableWithDependency(dependency: DependencyA()))
+    }
+
+    func test_injectableWithNamedDependency() throws {
+        container.registerModules(modules: [FakeTestModuleForInjecting()])
+        let testInjecting: InjectableWithNamedDependency = container.inject()
+        XCTAssertEqual(testInjecting, InjectableWithNamedDependency(name: 1))
     }
 }

--- a/Tests/WhoopDIKitTests/Injectable/InjectableTests.swift
+++ b/Tests/WhoopDIKitTests/Injectable/InjectableTests.swift
@@ -26,8 +26,8 @@ final class InjectableTests: XCTestCase {
            var newerThing: String { "not again" }
            let bestThing: Int
 
-            internal static func inject() -> Self {
-                Self.init(bestThing: WhoopDI.inject("Test"))
+            internal static func inject(container: Container) -> Self {
+                Self.init(bestThing: container.inject("Test"))
             }
 
             internal init(bestThing: Int) {
@@ -64,8 +64,8 @@ final class InjectableTests: XCTestCase {
            lazy var lazyVar: Double = 100
            let otherStringType: String.Type
 
-            public static func inject() -> Self {
-                Self.init(bestThing: WhoopDI.inject(nil), otherStringType: WhoopDI.inject(nil))
+            public static func inject(container: Container) -> Self {
+                Self.init(bestThing: container.inject(nil), otherStringType: container.inject(nil))
             }
 
             public init(bestThing: Int<String>, otherStringType: String.Type) {
@@ -95,8 +95,8 @@ final class InjectableTests: XCTestCase {
            var newerThing: String { "not again" }
            var bestThing: Int = 1
 
-            private static func inject() -> Self {
-                Self.init(bestThing: WhoopDI.inject(nil))
+            private static func inject(container: Container) -> Self {
+                Self.init(bestThing: container.inject(nil))
             }
 
             private init(bestThing: Int = 1) {
@@ -121,8 +121,8 @@ final class InjectableTests: XCTestCase {
             struct ClosureHolder {
                 let closure: () -> String
 
-                internal static func inject() -> Self {
-                    Self.init(closure: WhoopDI.inject(nil))
+                internal static func inject(container: Container) -> Self {
+                    Self.init(closure: container.inject(nil))
                 }
 
                 internal init(closure: @escaping () -> String) {

--- a/Tests/WhoopDIKitTests/Module/TestModules.swift
+++ b/Tests/WhoopDIKitTests/Module/TestModules.swift
@@ -49,11 +49,7 @@ class NilSingletonModule: DependencyModule {
 
 protocol Dependency { }
 
-class DependencyA: Dependency, Equatable {
-    static func == (lhs: DependencyA, rhs: DependencyA) -> Bool {
-        true
-    }
-}
+struct DependencyA: Dependency, Equatable { }
 
 class DependencyB: Dependency {
     private let param: String

--- a/Tests/WhoopDIKitTests/Module/TestModules.swift
+++ b/Tests/WhoopDIKitTests/Module/TestModules.swift
@@ -49,7 +49,11 @@ class NilSingletonModule: DependencyModule {
 
 protocol Dependency { }
 
-class DependencyA: Dependency { }
+class DependencyA: Dependency, Equatable {
+    static func == (lhs: DependencyA, rhs: DependencyA) -> Bool {
+        true
+    }
+}
 
 class DependencyB: Dependency {
     private let param: String
@@ -81,12 +85,19 @@ struct GenericDependency<T>: Dependency {
 
 class FakeTestModuleForInjecting: DependencyModule {
     override func defineDependencies() {
+        factory { DependencyA() }
         factory(name: "FakeName", factory: { 1 })
     }
 }
 
 @Injectable
-struct TestInjectingThing: Equatable {
+struct InjectableWithDependency: Equatable {
+    private let dependency: DependencyA
+}
+
+@Injectable
+struct InjectableWithNamedDependency: Equatable {
     @InjectableName(name: "FakeName")
     let name: Int
 }
+

--- a/Tests/WhoopDIKitTests/WhoopDITests.swift
+++ b/Tests/WhoopDIKitTests/WhoopDITests.swift
@@ -112,7 +112,7 @@ class WhoopDITests: XCTestCase {
 
     func test_injecting() {
         WhoopDI.registerModules(modules: [FakeTestModuleForInjecting()])
-        let testInjecting: TestInjectingThing = WhoopDI.inject()
-        XCTAssertEqual(testInjecting, TestInjectingThing(name: 1))
+        let testInjecting: InjectableWithNamedDependency = WhoopDI.inject()
+        XCTAssertEqual(testInjecting, InjectableWithNamedDependency(name: 1))
     }
 }


### PR DESCRIPTION
Updates the generated code to take in the injecting container. This will allow this to function correctly with child containers (eventually).