### PR TITLE
Fixes #13 Fix threading issue in local inject

### DIFF
--- a/Sources/WhoopDIKit/Container/Container.swift
+++ b/Sources/WhoopDIKit/Container/Container.swift
@@ -60,7 +60,7 @@ public final class Container {
     public func inject<T>(_ name: String? = nil,
                           params: Any? = nil,
                           _ localDefinition: (DependencyModule) -> Void) -> T {
-        return localDependencyGraph.aquireDependencyGraph { localServiceDict in
+        return localDependencyGraph.acquireDependencyGraph { localServiceDict in
             // Nested local injects are not currently supported. Fail fast here.
             guard !isLocalInjectActive else {
                 fatalError("Nesting WhoopDI.inject with local definitions is not currently supported")
@@ -113,7 +113,7 @@ public final class Container {
     }
 
     private func getDefinition(_ serviceKey: ServiceKey) -> DependencyDefinition? {
-        localDependencyGraph.aquireDependencyGraph { localServiceDict in
+        localDependencyGraph.acquireDependencyGraph { localServiceDict in
             return localServiceDict[serviceKey] ?? serviceDict[serviceKey]
         }
     }

--- a/Sources/WhoopDIKit/Container/ThreadSafeDependencyGraph.swift
+++ b/Sources/WhoopDIKit/Container/ThreadSafeDependencyGraph.swift
@@ -1,0 +1,35 @@
+import Foundation
+
+final class ThreadSafeDependencyGraph: Sendable {
+    private let lock = NSRecursiveLock()
+    nonisolated(unsafe) private let serviceDict: ServiceDictionary<DependencyDefinition> = .init()
+    private let options: WhoopDIOptionProvider
+    
+    init(options: WhoopDIOptionProvider) {
+        self.options = options
+    }
+    
+    func aquireDependencyGraph<T>(block: (ServiceDictionary<DependencyDefinition>) -> T) -> T {
+        let threadSafe = options.isOptionEnabled(.threadSafeLocalInject)
+        if threadSafe {
+            lock.lock()
+        }
+        let result = block(serviceDict)
+        if threadSafe {
+            lock.unlock()
+        }
+        return result
+    }
+    
+    func resetDependencyGraph() {
+        let threadSafe = options.isOptionEnabled(.threadSafeLocalInject)
+        if threadSafe {
+            lock.lock()
+        }
+        serviceDict.removeAll()
+        if threadSafe {
+            lock.unlock()
+        }
+    }
+    
+}

--- a/Sources/WhoopDIKit/Container/ThreadSafeDependencyGraph.swift
+++ b/Sources/WhoopDIKit/Container/ThreadSafeDependencyGraph.swift
@@ -1,8 +1,8 @@
 import Foundation
 
-final class ThreadSafeDependencyGraph: Sendable {
+final class ThreadSafeDependencyGraph: @unchecked Sendable {
     private let lock = NSRecursiveLock()
-    nonisolated(unsafe) private let serviceDict: ServiceDictionary<DependencyDefinition> = .init()
+    private let serviceDict: ServiceDictionary<DependencyDefinition> = .init()
     private let options: WhoopDIOptionProvider
     
     init(options: WhoopDIOptionProvider) {

--- a/Sources/WhoopDIKit/Container/ThreadSafeDependencyGraph.swift
+++ b/Sources/WhoopDIKit/Container/ThreadSafeDependencyGraph.swift
@@ -9,7 +9,7 @@ final class ThreadSafeDependencyGraph: Sendable {
         self.options = options
     }
     
-    func aquireDependencyGraph<T>(block: (ServiceDictionary<DependencyDefinition>) -> T) -> T {
+    func acquireDependencyGraph<T>(block: (ServiceDictionary<DependencyDefinition>) -> T) -> T {
         let threadSafe = options.isOptionEnabled(.threadSafeLocalInject)
         if threadSafe {
             lock.lock()

--- a/Sources/WhoopDIKit/DependencyError.swift
+++ b/Sources/WhoopDIKit/DependencyError.swift
@@ -1,13 +1,13 @@
 enum DependencyError: Error, CustomStringConvertible, Equatable {
     case badParams(ServiceKey)
-    case missingDependecy(ServiceKey)
+    case missingDependency(ServiceKey)
     case nilDependency(ServiceKey)
     
     var description: String {
         switch self {
         case .badParams(let serviceKey):
             return "Bad parameters provided for \(serviceKey.type) with name: \(serviceKey.name ?? "<no name>")"
-        case .missingDependecy(let serviceKey):
+        case .missingDependency(let serviceKey):
             return "Missing dependency for \(serviceKey.type) with name: \(serviceKey.name ?? "<no name>")"
         case .nilDependency(let serviceKey):
             return "Nil dependency for \(serviceKey.type) with name: \(serviceKey.name ?? "<no name>")"

--- a/Sources/WhoopDIKit/Options/DefaultOptionProvider.swift
+++ b/Sources/WhoopDIKit/Options/DefaultOptionProvider.swift
@@ -1,0 +1,9 @@
+struct DefaultOptionProvider: WhoopDIOptionProvider {
+    func isOptionEnabled(_ option: WhoopDIOption) -> Bool {
+        false
+    }
+}
+
+public func defaultWhoopDIOptions() -> WhoopDIOptionProvider {
+    DefaultOptionProvider()
+}

--- a/Sources/WhoopDIKit/Options/WhoopDIOption.swift
+++ b/Sources/WhoopDIKit/Options/WhoopDIOption.swift
@@ -1,0 +1,4 @@
+/// Options for WhoopDI. These are typically experimental features which may be enabled or disabled.
+public enum WhoopDIOption: Sendable {
+    case threadSafeLocalInject
+}

--- a/Sources/WhoopDIKit/Options/WhoopDIOptionProvider.swift
+++ b/Sources/WhoopDIKit/Options/WhoopDIOptionProvider.swift
@@ -1,0 +1,4 @@
+/// Implement this protocol and pass it into WhoopDI via `WhoopDI.setOptions` to enable and disable various options for WhoopDI.
+public protocol WhoopDIOptionProvider: Sendable {
+    func isOptionEnabled(_ option: WhoopDIOption) -> Bool
+}

--- a/Sources/WhoopDIKit/WhoopDI.swift
+++ b/Sources/WhoopDIKit/WhoopDI.swift
@@ -1,16 +1,23 @@
 import Foundation
 public final class WhoopDI: DependencyRegister {
-    nonisolated(unsafe) private static let appContainer = Container()
-    
+    nonisolated(unsafe) private static var appContainer = Container()
+
+    /// Setup WhoopDI with the supplied options.
+    /// This should only be called once when your application launches (and before WhoopDI is used).
+    /// By default all options are disabled if you do not call this method.
+    public static func setup(options: WhoopDIOptionProvider) {
+        appContainer = Container(options: options)
+    }
+
     /// Registers a list of modules with the DI system.
     /// Typically you will create a `DependencyModule` for your feature, then add it to the module list provided to this method.
     public static func registerModules(modules: [DependencyModule]) {
         appContainer.registerModules(modules: modules)
     }
     
-    /// Injects a dependecy into your code.
+    /// Injects a dependency into your code.
     ///
-    /// The injected dependecy will have all of it's sub-dependencies provided by the object graph defined in WhoopDI.
+    /// The injected dependency will have all of it's sub-dependencies provided by the object graph defined in WhoopDI.
     /// Typically this should be called from your top level UI object (ViewController, etc). Intermediate components should rely upon constructor injection (i.e providing dependencies via the constructor)
     public static func inject<T>(_ name: String? = nil, _ params: Any? = nil) -> T {
         appContainer.inject(name, params)
@@ -18,7 +25,7 @@ public final class WhoopDI: DependencyRegister {
     
     /// Injects a dependency into your code, overlaying local dependencies on top of the object graph.
     ///
-    /// The injected dependecy will have all of it's sub-dependencies provided by the object graph defined in WhoopDI.
+    /// The injected dependency will have all of it's sub-dependencies provided by the object graph defined in WhoopDI.
     /// Typically this should be called from your top level UI object (ViewController, etc). Intermediate components should rely
     /// upon constructor injection (i.e providing dependencies via the constructor).
     ///
@@ -36,12 +43,12 @@ public final class WhoopDI: DependencyRegister {
     ///   - name: An optional name for the dependency. This can help disambiguate between dependencies of the same type.
     ///   - params: Optional parameters which will be provided to dependencies which require them (i.e dependencies using defintiions such as
     ///   (factoryWithParams, etc).
-    ///   - localDefiniton: A local module definition which can be used to supply local dependencies to the object graph prior to injection.
+    ///   - localDefinition: A local module definition which can be used to supply local dependencies to the object graph prior to injection.
     /// - Returns: The requested dependency.
     public static func inject<T>(_ name: String? = nil,
                                  params: Any? = nil,
-                                 _ localDefiniton: (DependencyModule) -> Void) -> T {
-        appContainer.inject(name, params: params, localDefiniton)
+                                 _ localDefinition: (DependencyModule) -> Void) -> T {
+        appContainer.inject(name, params: params, localDefinition)
     }
     
     /// Used internally by the DependencyModule get to loop up a sub-dependency in the object graph.

--- a/Tests/WhoopDIKitTests/Container/ContainerTests.swift
+++ b/Tests/WhoopDIKitTests/Container/ContainerTests.swift
@@ -1,60 +1,94 @@
-import XCTest
+import Testing
 @testable import WhoopDIKit
 
-class ContainerTests: XCTestCase {
-    private let container = Container()
+// This is unchecked Sendable so we can run our local inject concurrency test
+@Suite(.serialized)
+class ContainerTests: @unchecked Sendable {
+    private let container: Container
+    
+    init() {
+        let options = MockOptionProvider(options: [.threadSafeLocalInject: true])
+        container = Container(options: options)
+    }
 
-    func test_inject() {
+    @Test
+    func inject() {
         container.registerModules(modules: [GoodTestModule()])
         let dependency: Dependency = container.inject("C_Factory", "param")
-        XCTAssertTrue(dependency is DependencyC)
+        #expect(dependency is DependencyC)
     }
 
-    func test_inject_generic_integer() {
+    @Test
+    func inject_generic_integer() {
         container.registerModules(modules: [GoodTestModule()])
         let dependency: GenericDependency<Int> = container.inject()
-        XCTAssertEqual(42, dependency.value)
+        #expect(42 == dependency.value)
     }
 
-    func test_inject_generic_string() {
+    @Test
+    func inject_generic_string() {
         container.registerModules(modules: [GoodTestModule()])
         let dependency: GenericDependency<String> = container.inject()
-        XCTAssertEqual("string", dependency.value)
+        #expect("string" == dependency.value)
     }
 
-    func test_inject_localDefinition() {
+    @Test
+    func inject_localDefinition() {
         container.registerModules(modules: [GoodTestModule()])
         let dependency: Dependency = container.inject("C_Factory") { module in
             // Typically you'd override or provide a transient dependency. I'm using the top level dependency here
             // for the sake of simplicity.
             module.factory(name: "C_Factory") { DependencyA() as Dependency }
         }
-        XCTAssertTrue(dependency is DependencyA)
+        #expect(dependency is DependencyA)
+    }
+    
+    @Test(.bug("https://github.com/WhoopInc/WhoopDI/issues/13"))
+    func inject_localDefinition_concurrency() async {
+        // You can run this test repeatedly to verify we don't have a concurrency issue when
+        // performing a local inject. 1000 times should do the trick.
+        container.registerModules(modules: [GoodTestModule()])
+        
+        async let resultA = Task {
+            let _: Dependency = container.inject("C_Factory") { module in
+                module.factory(name: "C_Factory") { DependencyA() as Dependency }
+            }
+        }.result
+        
+        async let resultB = Task {
+            let _: DependencyA = container.inject()
+        }.result
+        
+        let _ = await [resultA, resultB]
     }
 
-    func test_inject_localDefinition_noOverride() {
+    @Test
+    func inject_localDefinition_noOverride() {
         container.registerModules(modules: [GoodTestModule()])
         let dependency: Dependency = container.inject("C_Factory", params: "params") { _ in }
-        XCTAssertTrue(dependency is DependencyC)
+        #expect(dependency is DependencyC)
     }
 
-    func test_inject_localDefinition_withParams() {
+    @Test
+    func inject_localDefinition_withParams() {
         container.registerModules(modules: [GoodTestModule()])
         let dependency: Dependency = container.inject("C_Factory", params: "params") { module in
             module.factoryWithParams(name: "C_Factory") { params in DependencyB(params) as Dependency }
         }
-        XCTAssertTrue(dependency is DependencyB)
+        #expect(dependency is DependencyB)
     }
     
-    func test_injectableWithDependency() throws {
+    @Test
+    func injectableWithDependency() throws {
         container.registerModules(modules: [FakeTestModuleForInjecting()])
         let testInjecting: InjectableWithDependency = container.inject()
-        XCTAssertEqual(testInjecting, InjectableWithDependency(dependency: DependencyA()))
+        #expect(testInjecting == InjectableWithDependency(dependency: DependencyA()))
     }
 
-    func test_injectableWithNamedDependency() throws {
+    @Test
+    func injectableWithNamedDependency() throws {
         container.registerModules(modules: [FakeTestModuleForInjecting()])
         let testInjecting: InjectableWithNamedDependency = container.inject()
-        XCTAssertEqual(testInjecting, InjectableWithNamedDependency(name: 1))
+        #expect(testInjecting == InjectableWithNamedDependency(name: 1))
     }
 }

--- a/Tests/WhoopDIKitTests/Container/ContainerTests.swift
+++ b/Tests/WhoopDIKitTests/Container/ContainerTests.swift
@@ -2,7 +2,6 @@ import Testing
 @testable import WhoopDIKit
 
 // This is unchecked Sendable so we can run our local inject concurrency test
-@Suite(.serialized)
 class ContainerTests: @unchecked Sendable {
     private let container: Container
     
@@ -49,17 +48,15 @@ class ContainerTests: @unchecked Sendable {
         // performing a local inject. 1000 times should do the trick.
         container.registerModules(modules: [GoodTestModule()])
         
-        async let resultA = Task {
-            let _: Dependency = container.inject("C_Factory") { module in
+        Task.detached {
+            let _: Dependency = self.container.inject("C_Factory") { module in
                 module.factory(name: "C_Factory") { DependencyA() as Dependency }
             }
-        }.result
+        }
         
-        async let resultB = Task {
-            let _: DependencyA = container.inject()
-        }.result
-        
-        let _ = await [resultA, resultB]
+        Task.detached {
+            let _: DependencyA = self.container.inject()
+        }
     }
 
     @Test

--- a/Tests/WhoopDIKitTests/Container/ThreadSafeDependencyGraphTests.swift
+++ b/Tests/WhoopDIKitTests/Container/ThreadSafeDependencyGraphTests.swift
@@ -3,33 +3,33 @@ import Testing
 
 struct ThreadSafeDependencyGraphTests {
     @Test(arguments: [false, true])
-    func aquireDependencyGraph_notThreadSafe(threadsafe: Bool) {
+    func acquireDependencyGraph_notThreadSafe(threadsafe: Bool) {
         let options = MockOptionProvider(options: [.threadSafeLocalInject: threadsafe])
         let graph = ThreadSafeDependencyGraph(options: options)
         
-        graph.aquireDependencyGraph { serviceDict in
+        graph.acquireDependencyGraph { serviceDict in
             serviceDict[DependencyA.self] = FactoryDefinition(name: nil) { _ in DependencyA() }
         }
-        graph.aquireDependencyGraph { serviceDict in
+        graph.acquireDependencyGraph { serviceDict in
             let dependency = serviceDict[DependencyA.self]
             #expect(dependency != nil)
         }
         
         graph.resetDependencyGraph()
         
-        graph.aquireDependencyGraph { serviceDict in
+        graph.acquireDependencyGraph { serviceDict in
             let dependency = serviceDict[DependencyA.self]
             #expect(dependency == nil)
         }
     }
     
     @Test
-    func aquireDependencyGraph_recursive() {
+    func acquireDependencyGraph_recursive() {
         let options = MockOptionProvider(options: [.threadSafeLocalInject: true])
         let graph = ThreadSafeDependencyGraph(options: options)
         
-        graph.aquireDependencyGraph { outer in
-            graph.aquireDependencyGraph { serviceDict in
+        graph.acquireDependencyGraph { outer in
+            graph.acquireDependencyGraph { serviceDict in
                 serviceDict[DependencyA.self] = FactoryDefinition(name: nil) { _ in DependencyA() }
             }
             let dependency = outer[DependencyA.self]

--- a/Tests/WhoopDIKitTests/Container/ThreadSafeDependencyGraphTests.swift
+++ b/Tests/WhoopDIKitTests/Container/ThreadSafeDependencyGraphTests.swift
@@ -1,0 +1,41 @@
+import Testing
+@testable import WhoopDIKit
+
+struct ThreadSafeDependencyGraphTests {
+    private let key = "key"
+    
+    @Test(arguments: [false, true])
+    func aquireDependencyGraph_notThreadSafe(threadsafe: Bool) {
+        let options = MockOptionProvider(options: [.threadSafeLocalInject: threadsafe])
+        let graph = ThreadSafeDependencyGraph(options: options)
+        
+        graph.aquireDependencyGraph { serviceDict in
+            serviceDict[DependencyA.self] = FactoryDefinition(name: nil) { _ in DependencyA() }
+        }
+        graph.aquireDependencyGraph { serviceDict in
+            let dependency = serviceDict[DependencyA.self]
+            #expect(dependency != nil)
+        }
+        
+        graph.resetDependencyGraph()
+        
+        graph.aquireDependencyGraph { serviceDict in
+            let dependency = serviceDict[DependencyA.self]
+            #expect(dependency == nil)
+        }
+    }
+    
+    @Test
+    func aquireDependencyGraph_recursive() {
+        let options = MockOptionProvider(options: [.threadSafeLocalInject: true])
+        let graph = ThreadSafeDependencyGraph(options: options)
+        
+        graph.aquireDependencyGraph { outer in
+            graph.aquireDependencyGraph { serviceDict in
+                serviceDict[DependencyA.self] = FactoryDefinition(name: nil) { _ in DependencyA() }
+            }
+            let dependency = outer[DependencyA.self]
+            #expect(dependency != nil)
+        }
+    }
+}

--- a/Tests/WhoopDIKitTests/Container/ThreadSafeDependencyGraphTests.swift
+++ b/Tests/WhoopDIKitTests/Container/ThreadSafeDependencyGraphTests.swift
@@ -2,8 +2,6 @@ import Testing
 @testable import WhoopDIKit
 
 struct ThreadSafeDependencyGraphTests {
-    private let key = "key"
-    
     @Test(arguments: [false, true])
     func aquireDependencyGraph_notThreadSafe(threadsafe: Bool) {
         let options = MockOptionProvider(options: [.threadSafeLocalInject: threadsafe])

--- a/Tests/WhoopDIKitTests/DependencyErrorTests.swift
+++ b/Tests/WhoopDIKitTests/DependencyErrorTests.swift
@@ -17,15 +17,15 @@ class DependencyErrorTests: XCTestCase {
         XCTAssertEqual(expected, error.description)
     }
     
-    func test_description_missingDependecy_noServiceKeyName() {
+    func test_description_missingDependency_noServiceKeyName() {
         let expected = "Missing dependency for String with name: <no name>"
-        let error = DependencyError.missingDependecy(serviceKey)
+        let error = DependencyError.missingDependency(serviceKey)
         XCTAssertEqual(expected, error.description)
     }
     
-    func test_description_missingDependecy_withServiceKeyName() {
+    func test_description_missingDependency_withServiceKeyName() {
         let expected = "Missing dependency for String with name: name"
-        let error = DependencyError.missingDependecy(serviceKeyWithName)
+        let error = DependencyError.missingDependency(serviceKeyWithName)
         XCTAssertEqual(expected, error.description)
     }
     

--- a/Tests/WhoopDIKitTests/Module/DependencyDefinitionTests.swift
+++ b/Tests/WhoopDIKitTests/Module/DependencyDefinitionTests.swift
@@ -43,7 +43,7 @@ class DependencyDefinitionTests: XCTestCase {
     }
     
     func test_singleton_get_recoversFromThrow() {
-        let expectedError = DependencyError.missingDependecy(ServiceKey(String.self))
+        let expectedError = DependencyError.missingDependency(ServiceKey(String.self))
         var callCount = 0
         let definition = SingletonDefinition(name: nil) { _ -> Int in
             callCount += 1

--- a/Tests/WhoopDIKitTests/Module/DependencyModuleTests.swift
+++ b/Tests/WhoopDIKitTests/Module/DependencyModuleTests.swift
@@ -1,77 +1,96 @@
 import Foundation
-import XCTest
+import Testing
 @testable import WhoopDIKit
 
-class DependencyModuleTests: XCTestCase {
+@Suite(.serialized)
+class DependencyModuleTests {
     private let serviceKey = ServiceKey(String.self, name: "name")
     private let serviceDict = ServiceDictionary<DependencyDefinition>()
     
     private let module = DependencyModule()
     
-    func test_factory() {
+    @Test
+    func defineDependencies_defaultDoesNothing() {
+        module.defineDependencies()
+        module.addToServiceDictionary(serviceDict: serviceDict)
+        #expect(serviceDict.allKeys().isEmpty)
+    }
+    
+    @Test
+    func factory() {
         module.factory(name: "name") { "dependency" }
         module.addToServiceDictionary(serviceDict: serviceDict)
         
         let defintion = serviceDict[serviceKey]
-        XCTAssertTrue(defintion is FactoryDefinition)
+        #expect(defintion is FactoryDefinition)
     }
 
-    func test_get_missingContainer_fallsBackOnAppContainer() throws {
+    @Test
+    func get_missingContainer_fallsBackOnAppContainer() throws {
         WhoopDI.registerModules(modules: [GoodTestModule()])
+        
         let dependencyC: DependencyC = try module.get(params: "params")
-        XCTAssertNotNil(dependencyC)
+        #expect(dependencyC != nil)
+        
         WhoopDI.removeAllDependencies()
     }
 
-    func test_factoryWithParams() {
+    @Test
+    func factoryWithParams() {
         module.factoryWithParams(name: "name") { (_: Any) in "dependency" }
         module.addToServiceDictionary(serviceDict: serviceDict)
         
         let defintion = serviceDict[serviceKey]
-        XCTAssertTrue(defintion is FactoryDefinition)
+        #expect(defintion is FactoryDefinition)
     }
     
-    func test_singleton() {
+    @Test
+    func singleton() {
         module.singleton(name: "name") { "dependency" }
         module.addToServiceDictionary(serviceDict: serviceDict)
         
         let defintion = serviceDict[serviceKey]
-        XCTAssertTrue(defintion is SingletonDefinition)
+        #expect(defintion is SingletonDefinition)
     }
     
-    func test_singletonWithParams() {
+    @Test
+    func singletonWithParams() {
         module.singletonWithParams(name: "name") { (_: Any) in "dependency" }
         module.addToServiceDictionary(serviceDict: serviceDict)
         
         let defintion = serviceDict[serviceKey]
-        XCTAssertTrue(defintion is SingletonDefinition)
+        #expect(defintion is SingletonDefinition)
     }
     
-    func test_serviceKey_Returns_Subclass_Type() {
+    @Test
+    func serviceKey_Returns_Subclass_Type() {
         let testModule = TestDependencyModule(testModuleDependencies: [])
-        XCTAssertEqual(testModule.serviceKey, ServiceKey(type(of: TestDependencyModule())))
+        #expect(testModule.serviceKey == ServiceKey(type(of: TestDependencyModule())))
     }
     
-    func test_setMultipleModuleDependencies() {
+    @Test
+    func setMultipleModuleDependencies() {
         let moduleA = DependencyModule()
         let moduleB = DependencyModule()
         let moduleC = DependencyModule()
         let moduleD = DependencyModule()
         
         let module = TestDependencyModule(testModuleDependencies: [moduleD, moduleC, moduleB, moduleA])
-        XCTAssertEqual(module.moduleDependencies, [moduleD, moduleC, moduleB, moduleA])
+        #expect(module.moduleDependencies == [moduleD, moduleC, moduleB, moduleA])
     }
     
-    func test_setSingleModuleDependency() {
+    @Test
+    func setSingleModuleDependency() {
         let moduleA = DependencyModule()
         
         let module = TestDependencyModule(testModuleDependencies: [moduleA])
-        XCTAssertEqual(module.moduleDependencies, [moduleA])
+        #expect(module.moduleDependencies == [moduleA])
     }
     
-    func test_setNoModuleDependencies() {
+    @Test
+    func setNoModuleDependencies() {
         let module = TestDependencyModule()
-        XCTAssertEqual(module.moduleDependencies, [])
+        #expect(module.moduleDependencies.isEmpty)
     }
 }
 

--- a/Tests/WhoopDIKitTests/Module/DependencyModuleTests.swift
+++ b/Tests/WhoopDIKitTests/Module/DependencyModuleTests.swift
@@ -2,7 +2,7 @@ import Foundation
 import Testing
 @testable import WhoopDIKit
 
-@Suite(.serialized)
+@MainActor
 class DependencyModuleTests {
     private let serviceKey = ServiceKey(String.self, name: "name")
     private let serviceDict = ServiceDictionary<DependencyDefinition>()

--- a/Tests/WhoopDIKitTests/Options/DefaultOptionProviderTests.swift
+++ b/Tests/WhoopDIKitTests/Options/DefaultOptionProviderTests.swift
@@ -1,0 +1,11 @@
+import Foundation
+import Testing
+@testable import WhoopDIKit
+
+struct DefaultOptionProviderTests {
+    @Test func defaults() async throws {
+        let options = DefaultOptionProvider()
+        #expect(options.isOptionEnabled(.threadSafeLocalInject) == false)
+    }
+}
+

--- a/Tests/WhoopDIKitTests/Options/MockOptionProvider.swift
+++ b/Tests/WhoopDIKitTests/Options/MockOptionProvider.swift
@@ -1,0 +1,14 @@
+import Foundation
+@testable import WhoopDIKit
+
+struct MockOptionProvider: WhoopDIOptionProvider {
+    private let options: [WhoopDIOption: Bool]
+    
+    init(options: [WhoopDIOption : Bool] = [:]) {
+        self.options = options
+    }
+    
+    func isOptionEnabled(_ option: WhoopDIOption) -> Bool {
+        options[option] ?? false
+    }
+}

--- a/Tests/WhoopDIKitTests/WhoopDITests.swift
+++ b/Tests/WhoopDIKitTests/WhoopDITests.swift
@@ -1,17 +1,14 @@
 import Testing
 @testable import WhoopDIKit
 
-@Suite(.serialized)
+@MainActor
 class WhoopDITests {
-    deinit {
-        WhoopDI.removeAllDependencies()
-    }
-    
     @Test
     func inject() {
         WhoopDI.registerModules(modules: [GoodTestModule()])
         let dependency: Dependency = WhoopDI.inject("C_Factory", "param")
         #expect(dependency is DependencyC)
+        WhoopDI.removeAllDependencies()
     }
     
     @Test
@@ -19,6 +16,7 @@ class WhoopDITests {
         WhoopDI.registerModules(modules: [GoodTestModule()])
         let dependency: GenericDependency<Int> = WhoopDI.inject()
         #expect(42 == dependency.value)
+        WhoopDI.removeAllDependencies()
     }
     
     @Test
@@ -26,6 +24,7 @@ class WhoopDITests {
         WhoopDI.registerModules(modules: [GoodTestModule()])
         let dependency: GenericDependency<String> = WhoopDI.inject()
         #expect("string" == dependency.value)
+        WhoopDI.removeAllDependencies()
     }
     
     @Test
@@ -37,6 +36,7 @@ class WhoopDITests {
             module.factory(name: "C_Factory") { DependencyA() as Dependency }
         }
         #expect(dependency is DependencyA)
+        WhoopDI.removeAllDependencies()
     }
     
     @Test
@@ -53,6 +53,7 @@ class WhoopDITests {
         #expect(dependency1 is DependencyA)
         #expect(dependency2 is DependencyC)
         #expect(dependency3 is DependencyB)
+        WhoopDI.removeAllDependencies()
     }
     
     @Test
@@ -60,6 +61,7 @@ class WhoopDITests {
         WhoopDI.registerModules(modules: [GoodTestModule()])
         let dependency: Dependency = WhoopDI.inject("C_Factory", params: "params") { _ in }
         #expect(dependency is DependencyC)
+        WhoopDI.removeAllDependencies()
     }
     
     @Test
@@ -69,6 +71,7 @@ class WhoopDITests {
             module.factoryWithParams(name: "C_Factory") { params in DependencyB(params) as Dependency }
         }
         #expect(dependency is DependencyB)
+        WhoopDI.removeAllDependencies()
     }
     
     @Test
@@ -76,12 +79,14 @@ class WhoopDITests {
         WhoopDI.registerModules(modules: [FakeTestModuleForInjecting()])
         let testInjecting: InjectableWithNamedDependency = WhoopDI.inject()
         #expect(testInjecting == InjectableWithNamedDependency(name: 1))
+        WhoopDI.removeAllDependencies()
     }
     
     @Test
     func setup() {
         // Verify nothing explocdes
         WhoopDI.setup(options: DefaultOptionProvider())
+        WhoopDI.removeAllDependencies()
     }
     
     @Test
@@ -91,6 +96,7 @@ class WhoopDITests {
         var failed = false
         validator.validate { error in failed = true }
         #expect(failed)
+        WhoopDI.removeAllDependencies()
     }
     
     @Test
@@ -105,6 +111,7 @@ class WhoopDITests {
             failed = true
         }
         #expect(failed)
+        WhoopDI.removeAllDependencies()
     }
     
     
@@ -120,6 +127,7 @@ class WhoopDITests {
             failed = true
         }
         #expect(failed)
+        WhoopDI.removeAllDependencies()
     }
     
     @Test
@@ -134,6 +142,7 @@ class WhoopDITests {
             failed = true
         }
         #expect(failed)
+        WhoopDI.removeAllDependencies()
     }
     
     @Test
@@ -149,5 +158,6 @@ class WhoopDITests {
         validator.validate { error in
             Issue.record("DI failed with error: \(error)")
         }
+        WhoopDI.removeAllDependencies()
     }
 }

--- a/Tests/WhoopDIKitTests/WhoopDITests.swift
+++ b/Tests/WhoopDIKitTests/WhoopDITests.swift
@@ -3,7 +3,6 @@ import Testing
 
 @Suite(.serialized)
 class WhoopDITests {
-    
     deinit {
         WhoopDI.removeAllDependencies()
     }

--- a/Tests/WhoopDIKitTests/WhoopDITests.swift
+++ b/Tests/WhoopDIKitTests/WhoopDITests.swift
@@ -1,102 +1,144 @@
-import XCTest
+import Testing
 @testable import WhoopDIKit
 
-class WhoopDITests: XCTestCase {
+@Suite(.serialized)
+class WhoopDITests {
     
-    override func tearDown() {
+    deinit {
         WhoopDI.removeAllDependencies()
     }
     
-    func test_inject() {
+    @Test
+    func inject() {
         WhoopDI.registerModules(modules: [GoodTestModule()])
         let dependency: Dependency = WhoopDI.inject("C_Factory", "param")
-        XCTAssertTrue(dependency is DependencyC)
+        #expect(dependency is DependencyC)
     }
     
-    func test_inject_generic_integer() {
+    @Test
+    func inject_generic_integer() {
         WhoopDI.registerModules(modules: [GoodTestModule()])
         let dependency: GenericDependency<Int> = WhoopDI.inject()
-        XCTAssertEqual(42, dependency.value)
+        #expect(42 == dependency.value)
     }
     
-    func test_inject_generic_string() {
+    @Test
+    func inject_generic_string() {
         WhoopDI.registerModules(modules: [GoodTestModule()])
         let dependency: GenericDependency<String> = WhoopDI.inject()
-        XCTAssertEqual("string", dependency.value)
+        #expect("string" == dependency.value)
     }
     
-    func test_inject_localDefinition() {
+    @Test
+    func inject_localDefinition() {
         WhoopDI.registerModules(modules: [GoodTestModule()])
         let dependency: Dependency = WhoopDI.inject("C_Factory") { module in
             // Typically you'd override or provide a transient dependency. I'm using the top level dependency here
             // for the sake of simplicity.
             module.factory(name: "C_Factory") { DependencyA() as Dependency }
         }
-        XCTAssertTrue(dependency is DependencyA)
+        #expect(dependency is DependencyA)
     }
     
-    func test_inject_localDefinition_noOverride() {
+    @Test
+    func inject_localDefinition_multipleInjections() {
+        WhoopDI.registerModules(modules: [GoodTestModule()])
+        let dependency1: Dependency = WhoopDI.inject("C_Factory") { module in
+            module.factory(name: "C_Factory") { DependencyA() as Dependency }
+        }
+        let dependency2: Dependency = WhoopDI.inject("C_Factory", "params")
+        let dependency3: Dependency = WhoopDI.inject("C_Factory") { module in
+            module.factory(name: "C_Factory") { DependencyB("") as Dependency }
+        }
+        
+        #expect(dependency1 is DependencyA)
+        #expect(dependency2 is DependencyC)
+        #expect(dependency3 is DependencyB)
+    }
+    
+    @Test
+    func inject_localDefinition_noOverride() {
         WhoopDI.registerModules(modules: [GoodTestModule()])
         let dependency: Dependency = WhoopDI.inject("C_Factory", params: "params") { _ in }
-        XCTAssertTrue(dependency is DependencyC)
+        #expect(dependency is DependencyC)
     }
     
-    func test_inject_localDefinition_withParams() {
+    @Test
+    func inject_localDefinition_withParams() {
         WhoopDI.registerModules(modules: [GoodTestModule()])
         let dependency: Dependency = WhoopDI.inject("C_Factory", params: "params") { module in
             module.factoryWithParams(name: "C_Factory") { params in DependencyB(params) as Dependency }
         }
-        XCTAssertTrue(dependency is DependencyB)
+        #expect(dependency is DependencyB)
     }
     
-    func test_validation_fails_barParams() {
+    @Test
+    func injectable() {
+        WhoopDI.registerModules(modules: [FakeTestModuleForInjecting()])
+        let testInjecting: InjectableWithNamedDependency = WhoopDI.inject()
+        #expect(testInjecting == InjectableWithNamedDependency(name: 1))
+    }
+    
+    @Test
+    func setup() {
+        // Verify nothing explocdes
+        WhoopDI.setup(options: DefaultOptionProvider())
+    }
+    
+    @Test
+    func validation_fails_barParams() {
         WhoopDI.registerModules(modules: [GoodTestModule()])
         let validator = WhoopDIValidator()
         var failed = false
         validator.validate { error in failed = true }
-        XCTAssertTrue(failed)
+        #expect(failed)
     }
     
-    func test_validation_fails_missingDependencies() {
+    @Test
+    func validation_fails_missingDependencies() {
         WhoopDI.registerModules(modules: [BadTestModule()])
         let validator = WhoopDIValidator()
         var failed = false
         validator.validate { error in
             let expectedKey = ServiceKey(Dependency.self, name: "A_Factory")
-            let expectedError = DependencyError.missingDependecy(expectedKey)
-            XCTAssertEqual(expectedError, error as! DependencyError)
+            let expectedError = DependencyError.missingDependency(expectedKey)
+            #expect(expectedError == error as! DependencyError)
             failed = true
         }
-        XCTAssertTrue(failed)
+        #expect(failed)
     }
     
-    func test_validation_fails_nilFactoryDependency() {
+    
+    @Test
+    func validation_fails_nilFactoryDependency() {
         WhoopDI.registerModules(modules: [NilFactoryModule()])
         let validator = WhoopDIValidator()
         var failed = false
         validator.validate { error in
             let expectedKey = ServiceKey(Optional<Dependency>.self)
             let expectedError = DependencyError.nilDependency(expectedKey)
-            XCTAssertEqual(expectedError, error as! DependencyError)
+            #expect(expectedError == error as! DependencyError)
             failed = true
         }
-        XCTAssertTrue(failed)
+        #expect(failed)
     }
     
-    func test_validation_fails_nilSingletonDependency() {
+    @Test
+    func validation_fails_nilSingletonDependency() {
         WhoopDI.registerModules(modules: [NilSingletonModule()])
         let validator = WhoopDIValidator()
         var failed = false
         validator.validate { error in
             let expectedKey = ServiceKey(Optional<Dependency>.self)
             let expectedError = DependencyError.nilDependency(expectedKey)
-            XCTAssertEqual(expectedError, error as! DependencyError)
+            #expect(expectedError == error as! DependencyError)
             failed = true
         }
-        XCTAssertTrue(failed)
+        #expect(failed)
     }
     
-    func test_validation_succeeds() {
+    @Test
+    func validation_succeeds() {
         WhoopDI.registerModules(modules: [GoodTestModule()])
         let validator = WhoopDIValidator()
         validator.addParams("param", forType: Dependency.self, andName: "B_Factory")
@@ -106,13 +148,7 @@ class WhoopDITests: XCTestCase {
         validator.addParams("param", forType: Dependency.self, andName: "C_Factory")
         
         validator.validate { error in
-            XCTFail("DI failed with error: \(error)")
+            Issue.record("DI failed with error: \(error)")
         }
-    }
-
-    func test_injecting() {
-        WhoopDI.registerModules(modules: [FakeTestModuleForInjecting()])
-        let testInjecting: InjectableWithNamedDependency = WhoopDI.inject()
-        XCTAssertEqual(testInjecting, InjectableWithNamedDependency(name: 1))
     }
 }


### PR DESCRIPTION
- Add thread safety around local service dictionary in container.
- Adds mechanism to provide options / flags to WhoopDI so this functionality can be safely rolled out.