### PR TITLE
Add Task Local Inject Setup behind new option

### DIFF
--- a/Sources/WhoopDIKit/Container/ServiceDictionaryTaskLocal.swift
+++ b/Sources/WhoopDIKit/Container/ServiceDictionaryTaskLocal.swift
@@ -1,0 +1,26 @@
+enum ServiceDictionaryTaskLocal {
+    @TaskLocal
+    static var dictionary = ServiceDictionaryTaskLocalWrapper()
+}
+
+// This always returns copies and mutates copies, so there is no sendability worry here
+struct ServiceDictionaryTaskLocalWrapper: @unchecked Sendable {
+    private let serviceDictionary: ServiceDictionary<DependencyDefinition>?
+
+    init(serviceDictionary: ServiceDictionary<DependencyDefinition>? = nil) {
+        self.serviceDictionary = serviceDictionary
+    }
+
+    func withDependencyModuleUpdates<T>(dependencyModule: DependencyModule, perform: () throws -> T) rethrows -> T {
+        let dictionaryCopy = serviceDictionary?.copy() ?? ServiceDictionary()
+        dependencyModule.addToServiceDictionary(serviceDict: dictionaryCopy)
+        return try ServiceDictionaryTaskLocal.$dictionary.withValue(ServiceDictionaryTaskLocalWrapper(serviceDictionary: dictionaryCopy)) {
+            return try perform()
+        }
+
+    }
+
+    func getDependencyModule() -> ServiceDictionary<DependencyDefinition>? {
+        return serviceDictionary?.copy()
+    }
+}

--- a/Sources/WhoopDIKit/Options/WhoopDIOption.swift
+++ b/Sources/WhoopDIKit/Options/WhoopDIOption.swift
@@ -1,4 +1,5 @@
 /// Options for WhoopDI. These are typically experimental features which may be enabled or disabled.
 public enum WhoopDIOption: Sendable {
     case threadSafeLocalInject
+    case taskLocalInject
 }

--- a/Sources/WhoopDIKit/Service/ServiceDictionary.swift
+++ b/Sources/WhoopDIKit/Service/ServiceDictionary.swift
@@ -26,7 +26,11 @@ public final class ServiceDictionary<Value> {
             valuesByType[key] = newValue
         }
     }
-    
+
+    public func copy() -> Self {
+        return Self(valuesByType: self.valuesByType)
+    }
+
     public func allKeys() -> Set<ServiceKey> {
         Set(valuesByType.keys)
     }


### PR DESCRIPTION
Adds a way to inject values locally without locking. This allows us to do local injecting within local injecting since it will merge the two setups. All local injecting makes a _copy_ of the currently injecting service dictionary, which allows us to have the class be sendable, since we never mutate the same underlying object.