### PR TITLE
Add InjectableInit Macro

### DIFF
--- a/Sources/WhoopDIKit/Macros.swift
+++ b/Sources/WhoopDIKit/Macros.swift
@@ -10,3 +10,7 @@ public macro Injectable() = #externalMacro(module: "WhoopDIKitMacros", type: "In
 /// The `@InjectableName` macro is used as a marker for the `@Injectable` protocol to add a `WhoopDI.inject(name)` in the inject method
 @attached(peer)
 public macro InjectableName(name: String) = #externalMacro(module: "WhoopDIKitMacros", type: "InjectableNameMacro")
+
+/// The `@InjectableInit` macro is used as a marker for the `@Injectable` protocol to use as the init for the static `inject` function
+@attached(peer)
+public macro InjectableInit() = #externalMacro(module: "WhoopDIKitMacros", type: "InjectableInitMacro")

--- a/Sources/WhoopDIKitMacros/InjectableInitMacro.swift
+++ b/Sources/WhoopDIKitMacros/InjectableInitMacro.swift
@@ -1,0 +1,13 @@
+import SwiftSyntax
+import SwiftSyntaxMacros
+import SwiftSyntaxMacroExpansion
+
+struct InjectableInitMacro: PeerMacro {
+    static func expansion(of node: SwiftSyntax.AttributeSyntax, providingPeersOf declaration: some SwiftSyntax.DeclSyntaxProtocol, in context: some SwiftSyntaxMacros.MacroExpansionContext) throws -> [SwiftSyntax.DeclSyntax] {
+        guard declaration.kind == .initializerDecl else {
+            throw MacroExpansionErrorMessage("@InjectableInit can only be applied to an initializer")
+        }
+
+        return []
+    }
+}

--- a/Sources/WhoopDIKitMacros/Plugin.swift
+++ b/Sources/WhoopDIKitMacros/Plugin.swift
@@ -5,6 +5,7 @@ import SwiftSyntaxMacros
 struct WhoopDIKitPlugin: CompilerPlugin {
     let providingMacros: [Macro.Type] = [
         InjectableMacro.self, 
-        InjectableNameMacro.self
+        InjectableNameMacro.self,
+        InjectableInitMacro.self
     ]
 }

--- a/Sources/WhoopDIKitMacros/Support/VariableDeclaration.swift
+++ b/Sources/WhoopDIKitMacros/Support/VariableDeclaration.swift
@@ -35,6 +35,24 @@ extension DeclGroupSyntax {
         }
     }
 
+    var allInjectableInits: [InitializerDeclSyntax] {
+        self.memberBlock.members.compactMap { member in
+            if let initSyntax = member.decl.as(InitializerDeclSyntax.self),
+               initSyntax.attributes.contains(where: { element in
+                   switch element {
+                   case .attribute(let syntax):
+                       return syntax.attributeName.as(IdentifierTypeSyntax.self)?.name.text == "InjectableInit"
+                   default:
+                       return false
+                   }
+               }) {
+                return initSyntax
+            } else {
+                return nil
+            }
+        }
+    }
+
     private func injectableName(variableSyntax: VariableDeclSyntax) -> String? {
         variableSyntax.attributes.compactMap { (attribute) -> String? in
             switch attribute {

--- a/Tests/WhoopDIKitTests/Injectable/InjectableTests.swift
+++ b/Tests/WhoopDIKitTests/Injectable/InjectableTests.swift
@@ -41,6 +41,39 @@ final class InjectableTests: XCTestCase {
         macros: ["Injectable": InjectableMacro.self, "InjectableName": InjectableNameMacro.self])
     }
 
+    func testBasicInjectWithInjectableInit() {
+        assertMacroExpansion(
+        """
+        @Injectable struct TestThing {
+           let bestThing: Int
+        
+           @InjectableInit
+           internal init(notReal: Int, _ extraArg: String) {
+               self.bestThing = notReal
+           }
+        }
+        """,
+
+        expandedSource:
+        """
+        struct TestThing {
+           let bestThing: Int
+        
+           internal init(notReal: Int, _ extraArg: String) {
+               self.bestThing = notReal
+           }
+        
+            internal static func inject(container: Container) -> Self {
+                Self.init(notReal: container.inject(), container.inject())
+            }
+        }
+        
+        extension TestThing : Injectable {
+        }
+        """,
+        macros: ["Injectable": InjectableMacro.self, "InjectableName": InjectableNameMacro.self, "InjectableInit": InjectableInitMacro.self])
+    }
+
     func testInjectWithSpecifiers() {
         assertMacroExpansion(
         """


### PR DESCRIPTION
This adds an `InjectableInit` macro, which allows you to choose the initializer to use when injecting your object. This allows you to perform custom init but still use the `Injectable` macro

TODO:
- [ ] Figure out why the one init test is failing