### PR TITLE
Fixes #25 Make appContainer public

### DIFF
--- a/Sources/WhoopDIKit/WhoopDI.swift
+++ b/Sources/WhoopDIKit/WhoopDI.swift
@@ -1,6 +1,6 @@
 import Foundation
 public final class WhoopDI: DependencyRegister {
-    nonisolated(unsafe) private static var appContainer = Container()
+    nonisolated(unsafe) public private(set) static var appContainer = Container()
 
     /// Setup WhoopDI with the supplied options.
     /// This should only be called once when your application launches (and before WhoopDI is used).


### PR DESCRIPTION
This makes appContainer public, allowing client code to utilize the global container directly rather than via static WhoopDI methods.