### PR TITLE
Fixes #23 Local inject now correctly provides container to local module

### DIFF
--- a/Sources/WhoopDIKit/Container/Container.swift
+++ b/Sources/WhoopDIKit/Container/Container.swift
@@ -73,6 +73,7 @@ public final class Container {
             }
             
             let localModule = DependencyModule()
+            localModule.container = self
             localDefinition(localModule)
             localModule.addToServiceDictionary(serviceDict: localServiceDict)
             

--- a/Tests/WhoopDIKitTests/Container/ContainerTests.swift
+++ b/Tests/WhoopDIKitTests/Container/ContainerTests.swift
@@ -41,7 +41,21 @@ class ContainerTests: @unchecked Sendable {
         }
         #expect(dependency is DependencyA)
     }
-    
+
+    @Test(.bug("https://github.com/WhoopInc/WhoopDI/issues/23"))
+    func inject_localDefinition_dependenciesWithinLocalModule() {
+        container.registerModules(modules: [BadTestModule()])
+        let dependency: Dependency = container.inject("C_Factory", params: "params") { module in
+            module.factoryWithParams(name: "C_Factory") { params in
+                DependencyC(proto: try module.get("A_Factory"),
+                            concrete: try module.get(params: params)) as Dependency
+            }
+            module.factory(name: "A_Factory") { DependencyA() as Dependency }
+            module.factoryWithParams { params in DependencyB(params) }
+        }
+        #expect(dependency is DependencyC)
+    }
+
     @Test(.bug("https://github.com/WhoopInc/WhoopDI/issues/13"))
     func inject_localDefinition_concurrency() async {
         container.registerModules(modules: [GoodTestModule()])


### PR DESCRIPTION
Fixes #23 We now correctly set the container on the local module when using `inject { }`. This fixes the issue where local dependencies are not found when using a Container vs WhoopDI.