### PR TITLE
Fixes #24 InjectableName can now use variables along with constant strings

### DIFF
--- a/Sources/WhoopDIKitMacros/InjectableMacro.swift
+++ b/Sources/WhoopDIKitMacros/InjectableMacro.swift
@@ -54,7 +54,7 @@ struct InjectableMacro: ExtensionMacro, MemberMacro {
 
         // Creates the whoopdi calls in the `inject` func
         let injectingVariables: String = allVariables.map { variable in
-            "\(variable.name): container.inject(\(variable.injectedName.map { "\"\($0)\"" } ?? "nil"))"
+            "\(variable.name): container.inject(\(variable.injectedName.map { "\($0)" } ?? "nil"))"
         }.joined(separator: ", ")
 
         let accessLevel = self.accessLevel(declaration: declaration) ?? "internal"
@@ -116,18 +116,11 @@ struct InjectableMacro: ExtensionMacro, MemberMacro {
 }
 
 extension AttributeSyntax.Arguments {
-    // Get the first string literal in the argument list to the macro
-    var labeledContent: String? {
+    /// The expression associated with the name argument. `@InjectableName(name: <this>)`
+    var injectableNameExpression: ExprSyntax? {
         switch self {
         case let .argumentList(strList):
-            strList.compactMap { str in
-                str.expression.as(StringLiteralExprSyntax.self)?.segments.compactMap { (segment) -> String? in
-                    return switch segment {
-                    case .stringSegment(let segment): segment.content.text
-                    default: nil
-                    }
-                }.joined()
-            }.first
+            strList.filter { expr in expr.label?.text == "name" }.first?.expression
         default:
             nil
         }

--- a/Sources/WhoopDIKitMacros/Support/VariableDeclaration.swift
+++ b/Sources/WhoopDIKitMacros/Support/VariableDeclaration.swift
@@ -7,7 +7,7 @@ struct VariableDeclaration {
     let name: String
     let type: TypeSyntax
     let defaultExpression: ExprSyntax?
-    let injectedName: String?
+    let injectedName: ExprSyntax?
 }
 
 extension DeclGroupSyntax {
@@ -31,7 +31,10 @@ extension DeclGroupSyntax {
             ///  Becomes
             ///  init(..., myValue: Int = 100)
             let equalityExpression = declSyntax.bindings.first?.initializer?.value
-            return VariableDeclaration(name: propertyName, type: typeName, defaultExpression: equalityExpression, injectedName: injectedName)
+            return VariableDeclaration(name: propertyName,
+                                       type: typeName,
+                                       defaultExpression: equalityExpression,
+                                       injectedName: injectedName)
         }
     }
 
@@ -53,14 +56,14 @@ extension DeclGroupSyntax {
         }
     }
 
-    private func injectableName(variableSyntax: VariableDeclSyntax) -> String? {
-        variableSyntax.attributes.compactMap { (attribute) -> String? in
+    private func injectableName(variableSyntax: VariableDeclSyntax) -> ExprSyntax? {
+        variableSyntax.attributes.compactMap { attribute -> ExprSyntax? in
             switch attribute {
             case .attribute(let syntax):
                 // Check for `InjectableName` and then get the name from it
                 guard let name = syntax.attributeName.as(IdentifierTypeSyntax.self)?.name.text,
                         name == "InjectableName" else { return nil }
-                return syntax.arguments?.labeledContent
+                return syntax.arguments?.injectableNameExpression
             default: return nil
             }
         }.first

--- a/Tests/WhoopDIKitTests/Container/ContainerTests.swift
+++ b/Tests/WhoopDIKitTests/Container/ContainerTests.swift
@@ -9,28 +9,28 @@ class ContainerTests: @unchecked Sendable {
         let options = MockOptionProvider(options: [.threadSafeLocalInject: true])
         container = Container(options: options)
     }
-
+    
     @Test
     func inject() {
         container.registerModules(modules: [GoodTestModule()])
         let dependency: Dependency = container.inject("C_Factory", "param")
         #expect(dependency is DependencyC)
     }
-
+    
     @Test
     func inject_generic_integer() {
         container.registerModules(modules: [GoodTestModule()])
         let dependency: GenericDependency<Int> = container.inject()
         #expect(42 == dependency.value)
     }
-
+    
     @Test
     func inject_generic_string() {
         container.registerModules(modules: [GoodTestModule()])
         let dependency: GenericDependency<String> = container.inject()
         #expect("string" == dependency.value)
     }
-
+    
     @Test
     func inject_localDefinition() {
         container.registerModules(modules: [GoodTestModule()])
@@ -41,7 +41,7 @@ class ContainerTests: @unchecked Sendable {
         }
         #expect(dependency is DependencyA)
     }
-
+    
     @Test(.bug("https://github.com/WhoopInc/WhoopDI/issues/23"))
     func inject_localDefinition_dependenciesWithinLocalModule() {
         container.registerModules(modules: [BadTestModule()])
@@ -55,7 +55,7 @@ class ContainerTests: @unchecked Sendable {
         }
         #expect(dependency is DependencyC)
     }
-
+    
     @Test(.bug("https://github.com/WhoopInc/WhoopDI/issues/13"))
     func inject_localDefinition_concurrency() async {
         container.registerModules(modules: [GoodTestModule()])
@@ -66,24 +66,24 @@ class ContainerTests: @unchecked Sendable {
                     module.factory(name: "C_Factory") { DependencyA() as Dependency }
                 }
             }
-
+            
             let taskB = Task.detached {
                 let _: DependencyA = self.container.inject()
             }
-
+            
             for task in [taskA, taskB] {
                 let _ = await task.result
             }
         }
     }
-
+    
     @Test
     func inject_localDefinition_noOverride() {
         container.registerModules(modules: [GoodTestModule()])
         let dependency: Dependency = container.inject("C_Factory", params: "params") { _ in }
         #expect(dependency is DependencyC)
     }
-
+    
     @Test
     func inject_localDefinition_withParams() {
         container.registerModules(modules: [GoodTestModule()])
@@ -99,11 +99,14 @@ class ContainerTests: @unchecked Sendable {
         let testInjecting: InjectableWithDependency = container.inject()
         #expect(testInjecting == InjectableWithDependency(dependency: DependencyA()))
     }
-
+    
     @Test
     func injectableWithNamedDependency() throws {
         container.registerModules(modules: [FakeTestModuleForInjecting()])
         let testInjecting: InjectableWithNamedDependency = container.inject()
-        #expect(testInjecting == InjectableWithNamedDependency(name: 1))
+        let expected = InjectableWithNamedDependency(name: 1,
+                                                     nameFromVariable: "variable",
+                                                     globalVariableName: "global")
+        #expect(testInjecting == expected)
     }
 }

--- a/Tests/WhoopDIKitTests/Injectable/InjectableTests.swift
+++ b/Tests/WhoopDIKitTests/Injectable/InjectableTests.swift
@@ -11,27 +11,33 @@ final class InjectableTests: XCTestCase {
     func testBasicInject() {
         assertMacroExpansion(
         """
+        let worstName = "worst"
         @Injectable struct TestThing {
            let id: String = "no"
            var newerThing: String { "not again" }
            @InjectableName(name: "Test")
            let bestThing: Int
+           @InjectableName(name: worstName)
+           let worstThing: Int
         }
         """,
                              
         expandedSource:
         """
+        let worstName = "worst"
         struct TestThing {
            let id: String = "no"
            var newerThing: String { "not again" }
            let bestThing: Int
-
+           let worstThing: Int
+        
             internal static func inject(container: Container) -> Self {
-                Self.init(bestThing: container.inject("Test"))
+                Self.init(bestThing: container.inject("Test"), worstThing: container.inject(worstName))
             }
 
-            internal init(bestThing: Int) {
+            internal init(bestThing: Int, worstThing: Int) {
                 self.bestThing = bestThing
+                self.worstThing = worstThing
             }
         }
 

--- a/Tests/WhoopDIKitTests/Module/TestModules.swift
+++ b/Tests/WhoopDIKitTests/Module/TestModules.swift
@@ -82,7 +82,9 @@ struct GenericDependency<T>: Dependency {
 class FakeTestModuleForInjecting: DependencyModule {
     override func defineDependencies() {
         factory { DependencyA() }
-        factory(name: "FakeName", factory: { 1 })
+        factory(name: "FakeName") { 1 }
+        factory(name: "VariableFakeName") { "variable" }
+        factory(name: "GlobalVariableFakeName") { "global" }
     }
 }
 
@@ -91,9 +93,21 @@ struct InjectableWithDependency: Equatable {
     private let dependency: DependencyA
 }
 
+struct InjectableTestNames {
+    static let variableFakeName = "VariableFakeName"
+}
+
+let globalVariableFakeName: String = "GlobalVariableFakeName"
+
 @Injectable
 struct InjectableWithNamedDependency: Equatable {
     @InjectableName(name: "FakeName")
     let name: Int
+
+    @InjectableName(name: InjectableTestNames.variableFakeName)
+    let nameFromVariable: String
+
+    @InjectableName(name: globalVariableFakeName)
+    let globalVariableName: String
 }
 

--- a/Tests/WhoopDIKitTests/WhoopDITests.swift
+++ b/Tests/WhoopDIKitTests/WhoopDITests.swift
@@ -78,7 +78,10 @@ class WhoopDITests {
     func injectable() {
         WhoopDI.registerModules(modules: [FakeTestModuleForInjecting()])
         let testInjecting: InjectableWithNamedDependency = WhoopDI.inject()
-        #expect(testInjecting == InjectableWithNamedDependency(name: 1))
+        let expected = InjectableWithNamedDependency(name: 1,
+                                                     nameFromVariable: "variable",
+                                                     globalVariableName:  "global")
+        #expect(testInjecting == expected)
         WhoopDI.removeAllDependencies()
     }
     


### PR DESCRIPTION
Updates `InjectableName` processing to no longer assume name is a constant string.