### PR TITLE
Fixes #30 Provide more info in missing dep error

### DIFF
--- a/Sources/WhoopDIKit/Container/Container.swift
+++ b/Sources/WhoopDIKit/Container/Container.swift
@@ -97,7 +97,8 @@ public final class Container {
         } else if let injectable = T.self as? any Injectable.Type {
             return try injectable.inject(container: self) as! T
         } else  {
-            throw DependencyError.missingDependency(ServiceKey(T.self, name: name))
+            throw DependencyError.createMissingDependencyError(missingDependency: ServiceKey(T.self, name: name),
+                                                               serviceDict: serviceDict)
         }
     }
 

--- a/Sources/WhoopDIKit/DependencyError.swift
+++ b/Sources/WhoopDIKit/DependencyError.swift
@@ -1,16 +1,42 @@
 enum DependencyError: Error, CustomStringConvertible, Equatable {
     case badParams(ServiceKey)
-    case missingDependency(ServiceKey)
+    case missingDependency(missingDependency: ServiceKey, similarDependencies: Set<ServiceKey>, dependencyCount: Int)
     case nilDependency(ServiceKey)
     
     var description: String {
         switch self {
         case .badParams(let serviceKey):
             return "Bad parameters provided for \(serviceKey.type) with name: \(serviceKey.name ?? "<no name>")"
-        case .missingDependency(let serviceKey):
-            return "Missing dependency for \(serviceKey.type) with name: \(serviceKey.name ?? "<no name>")"
+        case .missingDependency(let missingDependency, let similarDependencies, let dependencyCount):
+            return missingDeendencyDescription(missingDependency, similarDependencies, dependencyCount)
         case .nilDependency(let serviceKey):
             return "Nil dependency for \(serviceKey.type) with name: \(serviceKey.name ?? "<no name>")"
         }
+    }
+
+    private func missingDeendencyDescription(_ missingDependency: ServiceKey,
+                                             _ similarDependencies: Set<ServiceKey>,
+                                             _ dependencyCount: Int) -> String {
+        let similarStrings = similarDependencies.map { "- \($0)" }.sorted()
+        let similarJoined = similarStrings.joined(separator: "\n")
+        let similarDescription = similarStrings.isEmpty ? "" : "\nSimilar dependencies:\n\(similarJoined)"
+
+        return """
+        Missing dependency for \(missingDependency)
+        Container has a total of \(dependencyCount) dependencies.
+        """ + similarDescription
+    }
+
+    static func createMissingDependencyError(
+        missingDependency: ServiceKey,
+        serviceDict: ServiceDictionary<DependencyDefinition>
+    ) -> DependencyError {
+        let similarDependencies = serviceDict.allKeys().filter { key in
+            key.name == missingDependency.name || key.type == missingDependency.type
+        }
+
+        return .missingDependency(missingDependency: missingDependency,
+                                  similarDependencies: similarDependencies,
+                                  dependencyCount: serviceDict.count)
     }
 }

--- a/Sources/WhoopDIKit/Service/ServiceDictionary.swift
+++ b/Sources/WhoopDIKit/Service/ServiceDictionary.swift
@@ -34,6 +34,10 @@ public final class ServiceDictionary<Value> {
     public func removeAll() {
         valuesByType.removeAll()
     }
+
+    public var count: Int {
+        valuesByType.count
+    }
 }
 
 public extension ServiceDictionary {

--- a/Sources/WhoopDIKit/Service/ServiceKey.swift
+++ b/Sources/WhoopDIKit/Service/ServiceKey.swift
@@ -1,12 +1,16 @@
 /// Hashable wrapper for a metatype value.
 /// See https://stackoverflow.com/questions/42459484/make-a-swift-dictionary-where-the-key-is-type
-public struct ServiceKey: Sendable {
+public struct ServiceKey: Sendable, CustomStringConvertible {
     public let type: Any.Type
     public let name: String?
     
     public init(_ type: Any.Type, name: String? = nil) {
         self.type = type
         self.name = name
+    }
+
+    public var description: String {
+        "\(type) with name: \(name ?? "<no name>")"
     }
 }
 

--- a/Tests/WhoopDIKitTests/Module/DependencyDefinitionTests.swift
+++ b/Tests/WhoopDIKitTests/Module/DependencyDefinitionTests.swift
@@ -43,7 +43,8 @@ class DependencyDefinitionTests: XCTestCase {
     }
     
     func test_singleton_get_recoversFromThrow() {
-        let expectedError = DependencyError.missingDependency(ServiceKey(String.self))
+        let expectedError = DependencyError.createMissingDependencyError(missingDependency: ServiceKey(String.self),
+                                                                         serviceDict: ServiceDictionary())
         var callCount = 0
         let definition = SingletonDefinition(name: nil) { _ -> Int in
             callCount += 1

--- a/Tests/WhoopDIKitTests/Service/ServiceDictionaryTests.swift
+++ b/Tests/WhoopDIKitTests/Service/ServiceDictionaryTests.swift
@@ -40,5 +40,6 @@ final class ServiceDictionaryTests: XCTestCase {
         XCTAssertEqual("string2", dictC[String.self])
         XCTAssertEqual("int2", dictC[Int.self])
         XCTAssertEqual("bool", dictC[Bool.self])
+        XCTAssertEqual(dictC.count, 3)
     }
 }

--- a/Tests/WhoopDIKitTests/WhoopDITests.swift
+++ b/Tests/WhoopDIKitTests/WhoopDITests.swift
@@ -109,7 +109,9 @@ class WhoopDITests {
         var failed = false
         validator.validate { error in
             let expectedKey = ServiceKey(Dependency.self, name: "A_Factory")
-            let expectedError = DependencyError.missingDependency(expectedKey)
+            let expectedError = DependencyError.missingDependency(missingDependency: expectedKey,
+                                                                  similarDependencies: Set(),
+                                                                  dependencyCount: 1)
             #expect(expectedError == error as! DependencyError)
             failed = true
         }


### PR DESCRIPTION
Error message will now look something like this:

```
Missing dependency for Dependency with name: A_Factory
Container has a total of 11 dependencies.
Similar dependencies:
- Dependency with name: <no name>
- Dependency with name: A_Single
- Dependency with name: B_Factory
- Dependency with name: B_Single
- Dependency with name: C_Factory
```