### PR TITLE
Fixes #8 DependencyTree is now internal to WhoopDI.

### DIFF
--- a/Sources/WhoopDIKit/Container/Container.swift
+++ b/Sources/WhoopDIKit/Container/Container.swift
@@ -13,8 +13,11 @@ public final class Container {
 
     /// Registers a list of modules with the DI system.
     /// Typically you will create a `DependencyModule` for your feature, then add it to the module list provided to this method.
+    /// Each provided module and it's dependencies will be registered with the DI system. 
+    /// Dependencies are registered in dependency order, with leaf modules (those with no dependencies) being registered first.
     public func registerModules(modules: [DependencyModule]) {
-        modules.forEach { module in
+        let tree = DependencyTree(dependencyModule: modules)
+        tree.modules.forEach { module in
             module.container = self
             module.defineDependencies()
             module.addToServiceDictionary(serviceDict: serviceDict)

--- a/Sources/WhoopDIKit/DependencyTree.swift
+++ b/Sources/WhoopDIKit/DependencyTree.swift
@@ -2,11 +2,11 @@ import Foundation
 
 /// Performs a depth first, post ordered search of the given module's dependency tree and flattens the tree into a list of modules
 /// in which the lowest level modules are ordered first.
-public final class DependencyTree {
+final class DependencyTree {
     
     private let dependencyModule: [DependencyModule]
     
-    public init(dependencyModule: [DependencyModule]) {
+    init(dependencyModule: [DependencyModule]) {
         self.dependencyModule = dependencyModule
         dependencyModule.forEach { module in
             self.traverseTree(for: module)
@@ -32,7 +32,7 @@ public final class DependencyTree {
     }
     
     /// Gets a list of dependent modules for the given module
-    public var modules: [DependencyModule] { 
+    var modules: [DependencyModule] { 
         get {
             return allModules
         }

--- a/Tests/WhoopDIKitTests/Container/ContainerTests.swift
+++ b/Tests/WhoopDIKitTests/Container/ContainerTests.swift
@@ -30,7 +30,15 @@ class ContainerTests: @unchecked Sendable {
         let dependency: GenericDependency<String> = container.inject()
         #expect("string" == dependency.value)
     }
-    
+
+    @Test
+    func inject_dependencyTree() {
+        let container = Container()
+        container.registerModules(modules: [ParentTestModule()])
+        let dependency: Dependency = container.inject()
+        #expect(dependency is DependencyC)
+    }
+
     @Test
     func inject_localDefinition() {
         container.registerModules(modules: [GoodTestModule()])

--- a/Tests/WhoopDIKitTests/Module/TestModules.swift
+++ b/Tests/WhoopDIKitTests/Module/TestModules.swift
@@ -88,6 +88,23 @@ class FakeTestModuleForInjecting: DependencyModule {
     }
 }
 
+class ChildTestModule: DependencyModule {
+    override func defineDependencies() {
+        factory(name: "a") { DependencyA() as Dependency }
+        factory { DependencyB("") }
+    }
+}
+
+class ParentTestModule: DependencyModule {
+    override var moduleDependencies: [DependencyModule] {
+        [ChildTestModule()]
+    }
+    
+    override func defineDependencies() {
+        factory { DependencyC(proto: try self.get("a"), concrete: try self.get()) as Dependency }
+    }
+}
+
 @Injectable
 struct InjectableWithDependency: Equatable {
     private let dependency: DependencyA


### PR DESCRIPTION
BREAKING CHANGE: DependencyTree is no longer public. It is used internally within Container, you no longer need to use it manually.