### PR TITLE
Fixes #34 Remove register modules functions

### DIFF
--- a/Sources/WhoopDIKit/Container/Container.swift
+++ b/Sources/WhoopDIKit/Container/Container.swift
@@ -7,16 +7,18 @@ public final class Container {
     
     private let serviceDict = ServiceDictionary<DependencyDefinition>()
 
-    public init(options: WhoopDIOptionProvider = defaultWhoopDIOptions()) {
+    /// Creates a container and registers a list of modules with the DI system.
+    /// Typically you will create a `DependencyModule` for your feature, then add it to the module list provided to this method.
+    /// Each provided module and it's dependencies will be registered with the DI system.
+    /// Dependencies are registered in dependency order, with leaf modules (those with no dependencies) being registered first.
+    public init(modules: [DependencyModule] = [],
+                options: WhoopDIOptionProvider = defaultWhoopDIOptions()) {
         self.options = options
         localDependencyGraph = ThreadSafeDependencyGraph(options: options)
+        registerModules(modules: modules)
     }
 
-    /// Registers a list of modules with the DI system.
-    /// Typically you will create a `DependencyModule` for your feature, then add it to the module list provided to this method.
-    /// Each provided module and it's dependencies will be registered with the DI system. 
-    /// Dependencies are registered in dependency order, with leaf modules (those with no dependencies) being registered first.
-    public func registerModules(modules: [DependencyModule]) {
+    private func registerModules(modules: [DependencyModule]) {
         let tree = DependencyTree(dependencyModule: modules)
         tree.modules.forEach { module in
             module.container = self

--- a/Sources/WhoopDIKit/DependencyRegister.swift
+++ b/Sources/WhoopDIKit/DependencyRegister.swift
@@ -1,4 +1,3 @@
 public protocol DependencyRegister {
     static func removeAllDependencies()
-    static func registerModules(modules: [DependencyModule])
 }

--- a/Sources/WhoopDIKit/WhoopDI.swift
+++ b/Sources/WhoopDIKit/WhoopDI.swift
@@ -5,14 +5,9 @@ public final class WhoopDI: DependencyRegister {
     /// Setup WhoopDI with the supplied options.
     /// This should only be called once when your application launches (and before WhoopDI is used).
     /// By default all options are disabled if you do not call this method.
-    public static func setup(options: WhoopDIOptionProvider) {
-        appContainer = Container(options: options)
-    }
-
-    /// Registers a list of modules with the DI system.
-    /// Typically you will create a `DependencyModule` for your feature, then add it to the module list provided to this method.
-    public static func registerModules(modules: [DependencyModule]) {
-        appContainer.registerModules(modules: modules)
+    public static func setup(modules: [DependencyModule],
+                             options: WhoopDIOptionProvider = defaultWhoopDIOptions()) {
+        appContainer = Container(modules: modules, options: options)
     }
     
     /// Injects a dependency into your code.
@@ -63,6 +58,6 @@ public final class WhoopDI: DependencyRegister {
     }
     
     public static func removeAllDependencies() {
-        appContainer.removeAllDependencies()
+        appContainer = Container()
     }
 }

--- a/Tests/WhoopDIKitTests/Container/ContainerConcurrencyTests.swift
+++ b/Tests/WhoopDIKitTests/Container/ContainerConcurrencyTests.swift
@@ -1,0 +1,33 @@
+import Testing
+@testable import WhoopDIKit
+
+// This is unchecked Sendable so we can run our local inject concurrency test
+class ContainerConcurrencyTests: @unchecked Sendable {
+    let container: Container
+
+    init() {
+        let options = MockOptionProvider(options: [.threadSafeLocalInject: true])
+        container = .init(modules: [GoodTestModule()], options: options)
+    }
+
+    @Test(.bug("https://github.com/WhoopInc/WhoopDI/issues/13"))
+    func inject_localDefinition_concurrency() async {
+
+        // Run many times to try and capture race condition
+        for _ in 0..<500 {
+            let taskA = Task.detached {
+                let _: Dependency = self.container.inject("C_Factory") { module in
+                    module.factory(name: "C_Factory") { DependencyA() as Dependency }
+                }
+            }
+            
+            let taskB = Task.detached {
+                let _: DependencyA = self.container.inject()
+            }
+            
+            for task in [taskA, taskB] {
+                let _ = await task.result
+            }
+        }
+    }
+}

--- a/Tests/WhoopDIKitTests/Module/DependencyModuleTests.swift
+++ b/Tests/WhoopDIKitTests/Module/DependencyModuleTests.swift
@@ -27,7 +27,7 @@ class DependencyModuleTests {
 
     @Test
     func get_missingContainer_fallsBackOnAppContainer() throws {
-        WhoopDI.registerModules(modules: [GoodTestModule()])
+        WhoopDI.setup(modules: [GoodTestModule()])
         
         let dependencyC: DependencyC = try module.get(params: "params")
         #expect(dependencyC != nil)

--- a/Tests/WhoopDIKitTests/WhoopDITests.swift
+++ b/Tests/WhoopDIKitTests/WhoopDITests.swift
@@ -5,7 +5,7 @@ import Testing
 class WhoopDITests {
     @Test
     func inject() {
-        WhoopDI.registerModules(modules: [GoodTestModule()])
+        WhoopDI.setup(modules: [GoodTestModule()])
         let dependency: Dependency = WhoopDI.inject("C_Factory", "param")
         #expect(dependency is DependencyC)
         WhoopDI.removeAllDependencies()
@@ -13,7 +13,7 @@ class WhoopDITests {
     
     @Test
     func inject_generic_integer() {
-        WhoopDI.registerModules(modules: [GoodTestModule()])
+        WhoopDI.setup(modules: [GoodTestModule()])
         let dependency: GenericDependency<Int> = WhoopDI.inject()
         #expect(42 == dependency.value)
         WhoopDI.removeAllDependencies()
@@ -21,7 +21,7 @@ class WhoopDITests {
     
     @Test
     func inject_generic_string() {
-        WhoopDI.registerModules(modules: [GoodTestModule()])
+        WhoopDI.setup(modules: [GoodTestModule()])
         let dependency: GenericDependency<String> = WhoopDI.inject()
         #expect("string" == dependency.value)
         WhoopDI.removeAllDependencies()
@@ -29,7 +29,7 @@ class WhoopDITests {
     
     @Test
     func inject_localDefinition() {
-        WhoopDI.registerModules(modules: [GoodTestModule()])
+        WhoopDI.setup(modules: [GoodTestModule()])
         let dependency: Dependency = WhoopDI.inject("C_Factory") { module in
             // Typically you'd override or provide a transient dependency. I'm using the top level dependency here
             // for the sake of simplicity.
@@ -41,7 +41,7 @@ class WhoopDITests {
     
     @Test
     func inject_localDefinition_multipleInjections() {
-        WhoopDI.registerModules(modules: [GoodTestModule()])
+        WhoopDI.setup(modules: [GoodTestModule()])
         let dependency1: Dependency = WhoopDI.inject("C_Factory") { module in
             module.factory(name: "C_Factory") { DependencyA() as Dependency }
         }
@@ -58,7 +58,7 @@ class WhoopDITests {
     
     @Test
     func inject_localDefinition_noOverride() {
-        WhoopDI.registerModules(modules: [GoodTestModule()])
+        WhoopDI.setup(modules: [GoodTestModule()])
         let dependency: Dependency = WhoopDI.inject("C_Factory", params: "params") { _ in }
         #expect(dependency is DependencyC)
         WhoopDI.removeAllDependencies()
@@ -66,7 +66,7 @@ class WhoopDITests {
     
     @Test
     func inject_localDefinition_withParams() {
-        WhoopDI.registerModules(modules: [GoodTestModule()])
+        WhoopDI.setup(modules: [GoodTestModule()])
         let dependency: Dependency = WhoopDI.inject("C_Factory", params: "params") { module in
             module.factoryWithParams(name: "C_Factory") { params in DependencyB(params) as Dependency }
         }
@@ -76,7 +76,7 @@ class WhoopDITests {
     
     @Test
     func injectable() {
-        WhoopDI.registerModules(modules: [FakeTestModuleForInjecting()])
+        WhoopDI.setup(modules: [FakeTestModuleForInjecting()])
         let testInjecting: InjectableWithNamedDependency = WhoopDI.inject()
         let expected = InjectableWithNamedDependency(name: 1,
                                                      nameFromVariable: "variable",
@@ -88,13 +88,13 @@ class WhoopDITests {
     @Test
     func setup() {
         // Verify nothing explocdes
-        WhoopDI.setup(options: DefaultOptionProvider())
+        WhoopDI.setup(modules: [], options: DefaultOptionProvider())
         WhoopDI.removeAllDependencies()
     }
     
     @Test
     func validation_fails_barParams() {
-        WhoopDI.registerModules(modules: [GoodTestModule()])
+        WhoopDI.setup(modules: [GoodTestModule()])
         let validator = WhoopDIValidator()
         var failed = false
         validator.validate { error in failed = true }
@@ -104,7 +104,7 @@ class WhoopDITests {
     
     @Test
     func validation_fails_missingDependencies() {
-        WhoopDI.registerModules(modules: [BadTestModule()])
+        WhoopDI.setup(modules: [BadTestModule()])
         let validator = WhoopDIValidator()
         var failed = false
         validator.validate { error in
@@ -122,7 +122,7 @@ class WhoopDITests {
     
     @Test
     func validation_fails_nilFactoryDependency() {
-        WhoopDI.registerModules(modules: [NilFactoryModule()])
+        WhoopDI.setup(modules: [NilFactoryModule()])
         let validator = WhoopDIValidator()
         var failed = false
         validator.validate { error in
@@ -137,7 +137,7 @@ class WhoopDITests {
     
     @Test
     func validation_fails_nilSingletonDependency() {
-        WhoopDI.registerModules(modules: [NilSingletonModule()])
+        WhoopDI.setup(modules: [NilSingletonModule()])
         let validator = WhoopDIValidator()
         var failed = false
         validator.validate { error in
@@ -152,7 +152,7 @@ class WhoopDITests {
     
     @Test
     func validation_succeeds() {
-        WhoopDI.registerModules(modules: [GoodTestModule()])
+        WhoopDI.setup(modules: [GoodTestModule()])
         let validator = WhoopDIValidator()
         validator.addParams("param", forType: Dependency.self, andName: "B_Factory")
         validator.addParams("param", forType: Dependency.self, andName: "B_Single")


### PR DESCRIPTION
BREAKING CHANGE: This removes register modules functions. 

Instead of registerModules, use the following:
- `WhoopDI.setup(modules: [...])`
- `Container(modules: [...]`