### PR TITLE
Fixes #44 Resolve lookup issue when dep is in parent

### DIFF
--- a/Sources/WhoopDIKit/Container/ContainerContext.swift
+++ b/Sources/WhoopDIKit/Container/ContainerContext.swift
@@ -1,0 +1,33 @@
+import Foundation
+
+/// A sendable wrapper around Container to enable use in TaskLocal context.
+/// This allows Container itself to remain non-Sendable while providing
+/// thread-safe access through this wrapper.
+final class SendableContainerWrapper: @unchecked Sendable {
+    let container: Container
+    
+    init(_ container: Container) {
+        self.container = container
+    }
+}
+
+/// TaskLocal container context for maintaining proper container references during dependency resolution.
+/// This ensures that when resolving dependencies across container boundaries, the correct container
+/// context is preserved throughout the injection process.
+enum ContainerContext {
+    /// The current container context for dependency resolution.
+    /// This TaskLocal variable maintains the appropriate container reference
+    /// during cross-container dependency injection scenarios.
+    @TaskLocal static var currentContainer: SendableContainerWrapper?
+    
+    /// Executes the given operation with the specified container set as the current TaskLocal context.
+    /// This utility method encapsulates the wrapper construction and ensures proper cleanup.
+    ///
+    /// - Parameters:
+    ///   - container: The container to set as the current context
+    ///   - operation: The operation to execute with the container context
+    /// - Returns: The result of the operation
+    static func withContainer<T>(_ container: Container, operation: () throws -> T) rethrows -> T {
+        return try $currentContainer.withValue(SendableContainerWrapper(container), operation: operation)
+    }
+}

--- a/Sources/WhoopDIKit/Module/DependencyModule.swift
+++ b/Sources/WhoopDIKit/Module/DependencyModule.swift
@@ -3,7 +3,6 @@ import Foundation
 /// Provides dependencies to the object graph. Modules can be registered with WhoopDI via `WhoopDI.registerModules`.
 open class DependencyModule {
     private var dependencies: [DependencyDefinition] = []
-    weak var container: Container? = nil
 
     public init() {
     }
@@ -75,10 +74,11 @@ open class DependencyModule {
     ///    }
     /// ```
     public final func get<T>(_ name: String? = nil, params: Any? = nil) throws -> T {
-        guard let container = container else {
+        if let containerWrapper = ContainerContext.currentContainer {
+            return try containerWrapper.container.get(name, params)
+        } else {
             return try WhoopDI.get(name, params)
         }
-        return try container.get(name, params)
     }
     
     /// Implement this method to define your dependencies.

--- a/Tests/WhoopDIKitTests/Container/ContainerTests.swift
+++ b/Tests/WhoopDIKitTests/Container/ContainerTests.swift
@@ -132,6 +132,25 @@ class ContainerTests {
         #expect(inheritedDependency.value == 42)
     }
 
+    @Test(.bug("https://github.com/WhoopInc/WhoopDI/issues/44"))
+    func createChild_crossContainerDependencies_shouldResolveSuccessfully() {
+        // This test reproduces the bug where dependencies span across container boundaries:
+        // Parent: DependencyG depends on Child's DependencyH
+        // Child: DependencyH available, DependencyI depends on Parent's DependencyG
+        
+        let parentContainer = createContainer(modules: [CrossContainerParentModule()])
+        let childContainer = parentContainer.createChild([CrossContainerChildModule()])
+        
+        // Child should be able to inject its own dependency
+        let _: DependencyH = childContainer.inject()
+        
+        // Child should be able to inject parent dependency that requires child dependency
+        let _: DependencyG = childContainer.inject()
+        
+        // Child should be able to inject its dependency that requires parent dependency
+        let _: DependencyI = childContainer.inject()
+    }
+
     private func createContainer(modules: [DependencyModule],
                                  localInjectWithoutMutation: Bool = true) -> Container {
         let options = MockOptionProvider(options: [

--- a/Tests/WhoopDIKitTests/Module/TestModules.swift
+++ b/Tests/WhoopDIKitTests/Module/TestModules.swift
@@ -138,3 +138,42 @@ struct InjectableWithNamedDependency: Equatable {
     let globalVariableName: String
 }
 
+// MARK: - Bug #44 Test Dependencies
+
+class DependencyG: Dependency {
+    private let dependencyH: DependencyH
+    
+    init(dependencyH: DependencyH) {
+        self.dependencyH = dependencyH
+    }
+}
+
+class DependencyH: Dependency { }
+
+class DependencyI: Dependency {
+    private let dependencyG: DependencyG
+    
+    init(dependencyG: DependencyG) {
+        self.dependencyG = dependencyG
+    }
+}
+
+// MARK: - Bug #44 Test Modules
+
+class CrossContainerParentModule: DependencyModule {
+    override func defineDependencies() {
+        // Parent dependency that requires child dependency H
+        factory { DependencyG(dependencyH: try self.get()) }
+    }
+}
+
+class CrossContainerChildModule: DependencyModule {
+    override func defineDependencies() {
+        // Child provides dependency H (required by parent)
+        factory { DependencyH() }
+        
+        // Child dependency I that requires parent dependency G
+        factory { DependencyI(dependencyG: try self.get()) }
+    }
+}
+


### PR DESCRIPTION
Fixes the issue where parent is relying on child to provide a dependency. Leverages task local to setup a container context so we don't need to break the API everywhere to pass down the child container.