### PR TITLE
Fixes #49 Enable immutable releases in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,4 +22,5 @@ jobs:
           allowUpdates: true
           draft: true
           generateReleaseNotes: true
+          immutableCreate: true
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
We've enabled this setting in the repo so we should also update the release action settings as well.