### PR TITLE
Fixes #51 Add codeowners and pin dependencies to explicit version

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# Code owners for WhoopDI
+* @ncipollo @jrosen081
+

--- a/Package.swift
+++ b/Package.swift
@@ -17,7 +17,7 @@ let package = Package(
             targets: ["WhoopDIKit",]),
     ],
     dependencies: [
-        .package(url: "https://github.com/swiftlang/swift-syntax.git", from: "600.0.0-latest")
+        .package(url: "https://github.com/swiftlang/swift-syntax.git", exact: "600.0.1")
     ],
     targets: [
         .target(


### PR DESCRIPTION
Adds the following:
- A CODEOwners file
- Pins the swift dependency to an explicit version (i.e avoid the floating latest tag)